### PR TITLE
Add default chat redirect when auth disabled

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,13 @@
+export const metadata = { title: 'Chatbot UI' };
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="ja">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,15 @@
+"use client"
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+
+export default function Home() {
+  const r = useRouter()
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_AUTH_DISABLED === "true") {
+      r.replace(
+        `/${process.env.NEXT_PUBLIC_DEFAULT_WORKSPACE_ID || "default"}/chat`
+      )
+    }
+  }, [r])
+  return <p>Loading…</p>
+}


### PR DESCRIPTION
## Summary
- add redirect logic in `app/page.tsx`
- implement server layout in `app/layout.tsx` to fix build error

## Testing
- `npm test` *(fails: jest not found)*